### PR TITLE
[cli] Fix an error that caused the server connection to close

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,6 +1,14 @@
 name: End to end tests
 
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - '!**'
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -328,7 +328,7 @@ class TestCli(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 1)
         self.assertIn("Error scheduling task", result.output)
-        self.assertEqual(len(http_requests), 1)
+        self.assertEqual(len(http_requests), 5)
 
 
 class TestGetRepository(unittest.TestCase):


### PR DESCRIPTION
This PR fixes an issue where the connection to the server was unexpectedly closed. It looks like the server did not keep the
session alive, causing it to close. As a result, when a new request is made, it fails.

Now, when there is a connection issue with the GrimoireLab server, the system attempts to reconnect and retry.

This change resolves the end-to-end tests running in GitHub Actions.